### PR TITLE
feat: Support Multiple Disabled Time Ranges in TimePicker

### DIFF
--- a/lib/painters/picker_painter.dart
+++ b/lib/painters/picker_painter.dart
@@ -20,14 +20,14 @@ class PickerPainter extends CustomPainter {
   /// Defines the decoration used for the picker.
   TimePickerDecoration pickerDecorator;
 
-  /// Defines the disabled time start angle of the picker.
-  double? disableTimeStartAngle;
+  /// Defines the disabled time start angles of the picker.
+  List<double?> disableTimeStartAngle;
 
-  /// Defines the disabled time end angle of the picker.
-  double? disableTimeEndAngle;
+  /// Defines the disabled time end angles of the picker.
+  List<double?> disableTimeEndAngle;
 
-  /// Defines the disabled time sweep angle of the picker.
-  double? disabledSweepAngle;
+  /// Defines the disabled time sweep angles of the picker.
+  List<double?> disabledSweepAngle;
 
   /// Defines the disabled range color.
   Color? disabledRangeColor;
@@ -69,9 +69,9 @@ class PickerPainter extends CustomPainter {
     required this.endAngle,
     required this.sweepAngle,
     required this.pickerDecorator,
-    this.disableTimeStartAngle,
-    this.disableTimeEndAngle,
-    this.disabledSweepAngle,
+    required this.disableTimeStartAngle,
+    required this.disableTimeEndAngle,
+    required this.disabledSweepAngle,
     this.disabledRangeColor,
     this.errorColor,
     this.drawInitHandlerOnTop = false,
@@ -91,27 +91,18 @@ class PickerPainter extends CustomPainter {
       sweepAngle,
     );
 
-    if (disableTimeStartAngle != null &&
-        disableTimeEndAngle != null &&
-        disabledSweepAngle != null) {
-      TimePickerSweepDecoration disableSweepDecorator =
-          TimePickerSweepDecoration(
-        pickerStrokeWidth: pickerDecorator.sweepDecoration.pickerStrokeWidth,
-        pickerColor: disabledRangeColor ?? Colors.grey.shade600,
-        connectorColor: pickerDecorator.sweepDecoration.connectorColor,
-        connectorStrokeWidth:
-            pickerDecorator.sweepDecoration.connectorStrokeWidth,
-        pickerGradient: pickerDecorator.sweepDecoration.pickerGradient,
-        showConnector: false,
-        useRoundedPickerCap: false,
-      );
-      disableSweepDecorator.paint(
-        canvas,
-        size,
-        center,
-        disableTimeStartAngle!,
-        disabledSweepAngle!,
-      );
+    if (disableTimeStartAngle.isNotEmpty &&
+        disableTimeEndAngle.isNotEmpty &&
+        disabledSweepAngle.isNotEmpty) {
+      for (int i = 0; i < disableTimeStartAngle.length; i++) {
+        _paintDisabledRange(
+          canvas,
+          size,
+          disableTimeStartAngle[i]!,
+          disableTimeEndAngle[i]!,
+          disabledSweepAngle[i]!,
+        );
+      }
     }
 
     if (drawInitHandlerOnTop) {
@@ -121,6 +112,26 @@ class PickerPainter extends CustomPainter {
       _drawStartHandler(canvas);
       _drawEndHandler(canvas);
     }
+  }
+
+  void _paintDisabledRange(Canvas canvas, Size size, double startAngle,
+      double endAngle, double sweepAngle) {
+    TimePickerSweepDecoration disableSweepDecorator = TimePickerSweepDecoration(
+      pickerStrokeWidth: pickerDecorator.sweepDecoration.pickerStrokeWidth,
+      pickerColor: disabledRangeColor ?? Colors.grey.shade600,
+      connectorColor: pickerDecorator.sweepDecoration.connectorColor,
+      connectorStrokeWidth: pickerDecorator.sweepDecoration.connectorStrokeWidth,
+      pickerGradient: pickerDecorator.sweepDecoration.pickerGradient,
+      showConnector: false,
+      useRoundedPickerCap: false,
+    );
+    disableSweepDecorator.paint(
+      canvas,
+      size,
+      center,
+      startAngle,
+      sweepAngle,
+    );
   }
 
   /// draw end handler

--- a/lib/painters/time_picker_painter.dart
+++ b/lib/painters/time_picker_painter.dart
@@ -20,8 +20,8 @@ class TimePickerPainter extends StatefulWidget {
   /// the end value
   final int end;
 
-  final int? disableTimeStart;
-  final int? disableTimeEnd;
+  final List<int?> disableTimeStart;
+  final List<int?> disableTimeEnd;
   final Color? disabledRangeColor;
   final Color? errorColor;
 
@@ -61,8 +61,8 @@ class TimePickerPainter extends StatefulWidget {
   TimePickerPainter({
     required this.init,
     required this.end,
-    this.disableTimeStart,
-    this.disableTimeEnd,
+    required this.disableTimeStart,
+    required this.disableTimeEnd,
     this.disabledRangeColor,
     this.errorColor,
     required this.child,
@@ -106,9 +106,9 @@ class _TimePickerPainterState extends State<TimePickerPainter> {
   /// the absolute angle in radians representing the selection
   late double _sweepAngle;
 
-  double? _disableTimeStartAngle;
-  double? _disableTimeEndAngle;
-  double? _disableSweepAngle;
+  List<double?> _disableTimeStartAngle = [];
+  List<double?> _disableTimeEndAngle = [];
+  List<double?> _disableSweepAngle = [];
 
   /// in case we have a double picker and we want to move the whole selection by
   /// clicking in the picker this will capture the position in the selection
@@ -190,17 +190,25 @@ class _TimePickerPainterState extends State<TimePickerPainter> {
     _endAngle = percentageToRadians(endPercent);
     _sweepAngle = percentageToRadians(sweep.abs());
 
-    if (widget.disableTimeStart != null && widget.disableTimeEnd != null) {
-      var disableTimeInitPercentage =
-          valueToPercentage(widget.disableTimeStart!, clockTimeDivision);
-      var disableTimeEndPercentage =
-          valueToPercentage(widget.disableTimeEnd!, clockTimeDivision);
-      var disabledSweep =
-          getSweepAngle(disableTimeInitPercentage, disableTimeEndPercentage);
+    _disableTimeStartAngle = [];
+    _disableTimeEndAngle = [];
+    _disableSweepAngle = [];
 
-      _disableTimeStartAngle = percentageToRadians(disableTimeInitPercentage);
-      _disableTimeEndAngle = percentageToRadians(disableTimeEndPercentage);
-      _disableSweepAngle = percentageToRadians(disabledSweep.abs());
+    if (widget.disableTimeStart.isNotEmpty &&
+        widget.disableTimeEnd.isNotEmpty) {
+      for (int i = 0; i < widget.disableTimeStart.length; i++) {
+        var disableTimeInitPercentage =
+            valueToPercentage(widget.disableTimeStart[i]!, clockTimeDivision);
+        var disableTimeEndPercentage =
+            valueToPercentage(widget.disableTimeEnd[i]!, clockTimeDivision);
+        var disabledSweep =
+            getSweepAngle(disableTimeInitPercentage, disableTimeEndPercentage);
+
+        _disableTimeStartAngle
+            .add(percentageToRadians(disableTimeInitPercentage));
+        _disableTimeEndAngle.add(percentageToRadians(disableTimeEndPercentage));
+        _disableSweepAngle.add(percentageToRadians(disabledSweep.abs()));
+      }
     }
 
     _painter = PickerPainter(

--- a/lib/src/time_picker.dart
+++ b/lib/src/time_picker.dart
@@ -61,7 +61,7 @@ class TimePicker extends StatefulWidget {
   final bool isSelectableHandlerMoveAble;
 
   /// used to disable Selection range, If null so there is no time range
-  final DisabledRange? disabledRange;
+  final List<DisabledRange>? disabledRanges;
 
   /// used to set priority to draw init or end handler on the top
   /// default value: false
@@ -85,7 +85,7 @@ class TimePicker extends StatefulWidget {
     this.isInitHandlerSelectable = true,
     this.isEndHandlerSelectable = true,
     this.isSelectableHandlerMoveAble = true,
-    this.disabledRange,
+    this.disabledRanges,
     this.drawInitHandlerOnTop = false,
   });
 }
@@ -94,11 +94,13 @@ class _TimePickerState extends State<TimePicker> {
   int _init = 0;
   int _end = 0;
 
-  int? _disabledInit;
-  int? _disabledEnd;
+  List<int?> disableTimeStart = [];
+  List<int?> disableTimeEnd = [];
+  List<int> _disabledInit = [];
+  List<int> _disabledEnd = [];
 
-  DateTime? disabledStartTime;
-  DateTime? disabledEndTime;
+  List<DateTime?> disabledStartTimes = [];
+  List<DateTime?> disabledEndTimes = [];
 
   bool? error;
 
@@ -113,7 +115,8 @@ class _TimePickerState extends State<TimePicker> {
   void didUpdateWidget(TimePicker oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.initTime != widget.initTime ||
-        oldWidget.endTime != widget.endTime) {
+        oldWidget.endTime != widget.endTime ||
+        oldWidget.disabledRanges != widget.disabledRanges) {
       _calculatePickerData();
     }
   }
@@ -138,28 +141,35 @@ class _TimePickerState extends State<TimePicker> {
               ClockIncrementTimeFormat.fiveMin,
     );
 
-    if (widget.disabledRange != null) {
-      disabledStartTime = getTime(widget.disabledRange!.initTime);
-      disabledEndTime = getTime(widget.disabledRange!.endTime);
+    _disabledInit = [];
+    _disabledEnd = [];
+    disabledStartTimes = [];
+    disabledEndTimes = [];
 
-      _disabledInit = pickedTimeToDivision(
-        pickedTime: widget.disabledRange!.initTime,
-        clockTimeFormat:
-            widget.decoration?.clockNumberDecoration?.clockTimeFormat ??
-                ClockTimeFormat.twentyFourHours,
-        clockIncrementTimeFormat: widget
-                .decoration?.clockNumberDecoration?.clockIncrementTimeFormat ??
-            ClockIncrementTimeFormat.fiveMin,
-      );
-      _disabledEnd = pickedTimeToDivision(
-        pickedTime: widget.disabledRange!.endTime,
-        clockTimeFormat:
-            widget.decoration?.clockNumberDecoration?.clockTimeFormat ??
-                ClockTimeFormat.twentyFourHours,
-        clockIncrementTimeFormat: widget
-                .decoration?.clockNumberDecoration?.clockIncrementTimeFormat ??
-            ClockIncrementTimeFormat.fiveMin,
-      );
+    if (widget.disabledRanges != null) {
+      for (var disabledRange in widget.disabledRanges!) {
+        disabledStartTimes.add(getTime(disabledRange.initTime));
+        disabledEndTimes.add(getTime(disabledRange.endTime));
+
+        _disabledInit.add(pickedTimeToDivision(
+          pickedTime: disabledRange.initTime,
+          clockTimeFormat:
+              widget.decoration?.clockNumberDecoration?.clockTimeFormat ??
+                  ClockTimeFormat.twentyFourHours,
+          clockIncrementTimeFormat: widget.decoration?.clockNumberDecoration
+                  ?.clockIncrementTimeFormat ??
+              ClockIncrementTimeFormat.fiveMin,
+        ));
+        _disabledEnd.add(pickedTimeToDivision(
+          pickedTime: disabledRange.endTime,
+          clockTimeFormat:
+              widget.decoration?.clockNumberDecoration?.clockTimeFormat ??
+                  ClockTimeFormat.twentyFourHours,
+          clockIncrementTimeFormat: widget.decoration?.clockNumberDecoration
+                  ?.clockIncrementTimeFormat ??
+              ClockIncrementTimeFormat.fiveMin,
+        ));
+      }
 
       error = validateRange(widget.initTime, widget.endTime);
     }
@@ -231,8 +241,9 @@ class _TimePickerState extends State<TimePicker> {
         end: _end,
         disableTimeStart: _disabledInit,
         disableTimeEnd: _disabledEnd,
-        disabledRangeColor: widget.disabledRange?.disabledRangeColor,
-        errorColor: widget.disabledRange?.errorColor,
+        disabledRangeColor:
+            widget.disabledRanges?.first.disabledRangeColor ?? Colors.grey,
+        errorColor: widget.disabledRanges?.first.errorColor ?? Colors.red,
         primarySectors: widget.primarySectors ?? 0,
         secondarySectors: widget.secondarySectors ?? 0,
         child: widget.child ?? Container(),
@@ -252,7 +263,7 @@ class _TimePickerState extends State<TimePicker> {
 
           bool? _valid;
 
-          if (widget.disabledRange != null) {
+          if (widget.disabledRanges != null) {
             _valid = validateRange(inTime, outTime);
             widget.onSelectionChange(inTime, outTime, _valid);
           } else {
@@ -279,7 +290,7 @@ class _TimePickerState extends State<TimePicker> {
                 ClockIncrementTimeFormat.fiveMin,
           );
 
-          if (widget.disabledRange != null) {
+          if (widget.disabledRanges != null) {
             bool _valid = validateRange(inTime, outTime);
             widget.onSelectionEnd(inTime, outTime, _valid);
             if (_valid != error) {
@@ -304,7 +315,7 @@ class _TimePickerState extends State<TimePicker> {
     if (error == false) {
       return widget.decoration?.copyWith(
         sweepDecoration: widget.decoration?.sweepDecoration.copyWith(
-          pickerColor: widget.disabledRange?.errorColor ?? Colors.red,
+          pickerColor: widget.disabledRanges?.first.errorColor ?? Colors.red,
         ),
       );
     }
@@ -316,40 +327,38 @@ class _TimePickerState extends State<TimePicker> {
     DateTime _newEnd = getTime(newEnd);
 
     if (_newStart.isAfter(_newEnd) || _newStart.isAtSameMomentAs(_newEnd)) {
-      if (disabledStartTime!.isAfter(_newStart) &&
-          disabledStartTime!
-              .isBefore(_newEnd.add(Duration(hours: widget.primarySectors!)))) {
-        return false;
-      }
-      if (disabledEndTime!.isAfter(_newStart) &&
-          disabledEndTime!
-              .isBefore(_newEnd.add(Duration(hours: widget.primarySectors!)))) {
-        return false;
-      }
       _newStart = _newStart.add(Duration(hours: -widget.primarySectors!));
     }
-    if (disabledStartTime!.isAfter(disabledEndTime!) ||
-        disabledStartTime!.isAtSameMomentAs(disabledEndTime!)) {
-      disabledStartTime =
-          disabledStartTime!.add(Duration(hours: -widget.primarySectors!));
-    }
-    if (_newStart.isAfter(disabledStartTime!) &&
-        _newStart.isBefore(disabledEndTime!)) {
-      return false;
-    }
-    if (_newEnd.isAfter(disabledStartTime!) &&
-        _newEnd.isBefore(disabledEndTime!)) {
-      return false;
+
+    for (int i = 0; i < disabledStartTimes.length; i++) {
+      DateTime disabledStartTime = disabledStartTimes[i]!;
+      DateTime disabledEndTime = disabledEndTimes[i]!;
+
+      if (disabledStartTime.isAfter(disabledEndTime) ||
+          disabledStartTime.isAtSameMomentAs(disabledEndTime)) {
+        disabledStartTime =
+            disabledStartTime.add(Duration(hours: -widget.primarySectors!));
+      }
+
+      if (_newStart.isAfter(disabledStartTime) &&
+          _newStart.isBefore(disabledEndTime)) {
+        return false;
+      }
+      if (_newEnd.isAfter(disabledStartTime) &&
+          _newEnd.isBefore(disabledEndTime)) {
+        return false;
+      }
+
+      if (disabledStartTime.isAfter(_newStart) &&
+          disabledStartTime.isBefore(_newEnd)) {
+        return false;
+      }
+      if (disabledEndTime.isAfter(_newStart) &&
+          disabledEndTime.isBefore(_newEnd)) {
+        return false;
+      }
     }
 
-    if (disabledStartTime!.isAfter(_newStart) &&
-        disabledStartTime!.isBefore(_newEnd)) {
-      return false;
-    }
-    if (disabledEndTime!.isAfter(_newStart) &&
-        disabledEndTime!.isBefore(_newEnd)) {
-      return false;
-    }
     return true;
   }
 

--- a/lib/src/time_picker.dart
+++ b/lib/src/time_picker.dart
@@ -233,6 +233,7 @@ class _TimePickerState extends State<TimePicker> {
 
   @override
   Widget build(BuildContext context) {
+    var hasDisabledRanges = widget.disabledRanges != null && widget.disabledRanges!.isNotEmpty;
     return Container(
       height: widget.height ?? 220,
       width: widget.width ?? 220,
@@ -241,9 +242,8 @@ class _TimePickerState extends State<TimePicker> {
         end: _end,
         disableTimeStart: _disabledInit,
         disableTimeEnd: _disabledEnd,
-        disabledRangeColor:
-            widget.disabledRanges?.first.disabledRangeColor ?? Colors.grey,
-        errorColor: widget.disabledRanges?.first.errorColor ?? Colors.red,
+        disabledRangeColor: hasDisabledRanges ? widget.disabledRanges?.first.disabledRangeColor : Colors.grey,
+        errorColor: hasDisabledRanges ? widget.disabledRanges?.first.errorColor : Colors.red,
         primarySectors: widget.primarySectors ?? 0,
         secondarySectors: widget.secondarySectors ?? 0,
         child: widget.child ?? Container(),


### PR DESCRIPTION
This PR adds support for multiple disabled time ranges in the `TimePicker` widget. Previously, only a single disabled range could be specified using the `disabledRange` property. This enhancement allows for more flexible time selection restrictions by enabling multiple, non-overlapping disabled ranges.

The following changes were made to achieve this:

- **`TimePicker` widget:** The `disabledRange` property has been replaced with `disabledRanges`, which accepts a list of `DisabledRange` objects.
- **`TimePickerPainter` widget:**  The internal logic for handling disabled ranges has been updated to iterate through the `disabledRanges` list and paint each disabled range accordingly.  The `disableTimeStart`, `disableTimeEnd`, and `disabledSweepAngle` properties are now lists to accommodate multiple ranges.
- **`PickerPainter`:** The `paint` method now iterates through the provided list of disabled start/end angles and sweep angles to render each disabled range. A new helper method `_paintDisabledRange` was added to encapsulate the painting logic for a single disabled range.
- **`_TimePickerState`:** The state management logic has been updated to handle lists of disabled start/end times. The `validateRange` method now checks against all disabled ranges provided.

This enhancement addresses the need for more granular control over disabled time selections, enabling scenarios where multiple specific time slots need to be excluded.

![gif](https://github.com/user-attachments/assets/a4e97eea-e0e3-40c5-9841-a118bd1b0e35)
